### PR TITLE
Add a variant called Ioskeley Mono Term for terminal emulators

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,11 @@ Download the latest release from the [Releases page](https://github.com/ahatem/I
 
 **Step 1 — Pick your use case:**
 
-| I want to… | Download |
-|---|---|
-| Use it in my editor / IDE | A TTF zip |
-| Use it in my terminal with icons | A Nerd Font zip |
-| Use it on the web | `IoskeleyMono-Web.zip` |
+| I want to…                       | Download                              |
+|----------------------------------|---------------------------------------|
+| Use it in my editor / IDE        | A TTF zip                             |
+| Use it in my terminal with icons | A Nerd Font zip of Ioskeley Mono Term |
+| Use it on the web                | `IoskeleyMono-Web.zip`                |
 
 **Step 2 — Pick your width:**
 
@@ -88,6 +88,12 @@ For the full list of configuration choices, see [`private-build-plans.toml`](./p
 
 ---
 
+## Ioskeley Mono Term
+
+This is a variant of Ioskeley Mono tuned for terminal emulators. It has narrower arrows and geometric symbols.
+
+---
+
 ## Building from Source
 
 The font is built automatically via GitHub Actions on every version tag push. To build locally:
@@ -104,6 +110,14 @@ npm run build -- contents::IoskeleyMono
 
 Output will be in `Iosevka/dist/IoskeleyMono/`.
 
+To build the terminal variant afterward:
+
+```bash
+npm run build -- contents::IoskeleyMonoTerm
+```
+
+Output will be in `Iosevka/dist/IoskeleyMonoTerm/`.
+
 ---
 
 ## Contributing
@@ -114,6 +128,6 @@ This project is just a build configuration on top of Iosevka — changes are oft
 
 ## License & Credits
 
-Ioskeley Mono is a custom configuration of [Iosevka](https://github.com/be5invis/Iosevka). All credit for the original design and build system goes to [Belleve Invis](https://github.com/be5invis) and the Iosevka contributors.
+Ioskeley Mono and Ioskeley Mono Term are a custom configuration of [Iosevka](https://github.com/be5invis/Iosevka). All credit for the original design and build system goes to [Belleve Invis](https://github.com/be5invis) and the Iosevka contributors.
 
 Licensed under the [SIL Open Font License 1.1](./LICENSE).

--- a/private-build-plans.toml
+++ b/private-build-plans.toml
@@ -222,3 +222,49 @@ essRatioLower = 1.03
 essRatioQuestion = 1.03
 archDepth = 152
 smallArchDepth = 157
+
+
+# ============================================================
+# IOSKELEY MONO TERM
+# Identical to Ioskeley Mono, but with spacing appropriate for
+# terminal emulators.
+# ============================================================
+
+[buildPlans.IoskeleyMonoTerm]
+family = "Ioskeley Mono Term"
+spacing = "term"
+serifs = "sans"
+noCvSs = true
+exportGlyphNames = false
+
+[buildPlans.IoskeleyMonoTerm.variants]
+inherits = "buildPlans.IoskeleyMono"
+[buildPlans.IoskeleyMonoTerm.weights]
+inherits = "buildPlans.IoskeleyMono"
+[buildPlans.IoskeleyMonoTerm.widths]
+inherits = "buildPlans.IoskeleyMono"
+[buildPlans.IoskeleyMonoTerm.slopes]
+inherits = "buildPlans.IoskeleyMono"
+
+[buildPlans.IoskeleyMonoTerm.metricOverride]
+xHeight = 520
+cap = 690
+ascender = 740
+sb = 85
+
+accentWidth = 182
+accentClearance = 76
+accentHeight = 162
+accentStackOffset = 208
+
+leading = 1250
+parenSize = 860
+dotSize = 'blend(weight, [100, 110], [400, 125], [900, 150])'
+periodSize = 140
+
+essRatio = 1.03
+essRatioUpper = 1.03
+essRatioLower = 1.03
+essRatioQuestion = 1.03
+archDepth = 152
+smallArchDepth = 157


### PR DESCRIPTION
First of all, thank you for creating this font! 🙇🏻 

I primarily use it in a terminal and found that arrows look a bit off:

<img width="137" height="36" alt="image" src="https://github.com/user-attachments/assets/871a5a28-3a34-4861-abb3-0cf423ae3cb4" />

`↑11k ↓467 Δ11k`

This PR adds "Ioskeley Mono Term", similar to Iosevka's "Iosevka Term" variant, which is identical to the original, except sets `spacing = "term"` resulting in better arrows rendering:

<img width="139" height="33" alt="image" src="https://github.com/user-attachments/assets/bae969f0-a4cb-4ea7-a0f7-3d0611040db3" />

Note: `metricOverride` are a copy-paste, because I couldn't find an equivalent `inherits` in the upstream docs. I tried my best with the README.md, but I'm happy to undo those changes if you prefer.