### PR TITLE
feat: add quasi-proportional variants

### DIFF
--- a/.github/workflows/build-font.yml
+++ b/.github/workflows/build-font.yml
@@ -45,7 +45,7 @@ jobs:
           cp private-build-plans.toml iosevka-src/
           cd iosevka-src
           npm install
-          npm run build -- contents::IoskeleyMono contents::IoskeleyMonoTerm contents::IoskeleyMonoNL
+          npm run build -- contents::IoskeleyMono contents::IoskeleyMonoTerm contents::IoskeleyMonoNL contents::IoskeleySans contents::IoskeleySansNL
 
       - name: Verify build output
         run: |
@@ -59,6 +59,14 @@ jobs:
           fi
           if [ ! -d "iosevka-src/dist/IoskeleyMonoNL/TTF" ]; then
             echo "IoskeleyMonoNL build output not found!"
+            exit 1
+          fi
+          if [ ! -d "iosevka-src/dist/IoskeleySans/TTF" ] || [ ! -d "iosevka-src/dist/IoskeleySans/WOFF2" ]; then
+            echo "IoskeleySans build output not found!"
+            exit 1
+          fi
+          if [ ! -d "iosevka-src/dist/IoskeleySansNL/TTF" ]; then
+            echo "IoskeleySansNL build output not found!"
             exit 1
           fi
 
@@ -78,57 +86,88 @@ jobs:
           mkdir -p patched-fonts/Normal patched-fonts/SemiCondensed patched-fonts/Condensed
           mkdir -p patched-fonts-term/Normal patched-fonts-term/SemiCondensed patched-fonts-term/Condensed
           mkdir -p patched-fonts-nl/Normal patched-fonts-nl/SemiCondensed patched-fonts-nl/Condensed
+          mkdir -p patched-fonts-quasi/Normal patched-fonts-quasi/SemiCondensed patched-fonts-quasi/Condensed
+          mkdir -p patched-fonts-quasi-nl/Normal patched-fonts-quasi-nl/SemiCondensed patched-fonts-quasi-nl/Condensed
+
           DIST="iosevka-src/dist/IoskeleyMono/TTF"
           DIST_TERM="iosevka-src/dist/IoskeleyMonoTerm/TTF"
           DIST_NL="iosevka-src/dist/IoskeleyMonoNL/TTF"
+          DIST_QUASI="iosevka-src/dist/IoskeleySans/TTF"
+          DIST_QUASI_NL="iosevka-src/dist/IoskeleySansNL/TTF"
           PATCHER="nerd-fonts-patcher/font-patcher"
 
+          # ── Patch Mono ──
           for font in "$DIST"/IoskeleyMono-SemiCondensed*.ttf; do
             fontforge -script "$PATCHER" "$font" --complete --careful --outputdir patched-fonts/SemiCondensed
           done
-
           for font in "$DIST"/IoskeleyMono-Condensed*.ttf; do
             [[ "$font" == *SemiCondensed* ]] && continue
             fontforge -script "$PATCHER" "$font" --complete --careful --outputdir patched-fonts/Condensed
           done
-
           for font in "$DIST"/IoskeleyMono-*.ttf; do
             [[ "$font" == *Condensed* ]] && continue
             fontforge -script "$PATCHER" "$font" --complete --careful --outputdir patched-fonts/Normal
           done
 
+          # ── Patch Term ──
           for font in "$DIST_TERM"/IoskeleyMonoTerm-SemiCondensed*.ttf; do
             fontforge -script "$PATCHER" "$font" --complete --careful --outputdir patched-fonts-term/SemiCondensed
           done
-
           for font in "$DIST_TERM"/IoskeleyMonoTerm-Condensed*.ttf; do
             [[ "$font" == *SemiCondensed* ]] && continue
             fontforge -script "$PATCHER" "$font" --complete --careful --outputdir patched-fonts-term/Condensed
           done
-
           for font in "$DIST_TERM"/IoskeleyMonoTerm-*.ttf; do
             [[ "$font" == *Condensed* ]] && continue
             fontforge -script "$PATCHER" "$font" --complete --careful --outputdir patched-fonts-term/Normal
           done
 
+          # ── Patch NL ──
           for font in "$DIST_NL"/IoskeleyMonoNL-SemiCondensed*.ttf; do
             fontforge -script "$PATCHER" "$font" --complete --careful --outputdir patched-fonts-nl/SemiCondensed
           done
-
           for font in "$DIST_NL"/IoskeleyMonoNL-Condensed*.ttf; do
             [[ "$font" == *SemiCondensed* ]] && continue
             fontforge -script "$PATCHER" "$font" --complete --careful --outputdir patched-fonts-nl/Condensed
           done
-
           for font in "$DIST_NL"/IoskeleyMonoNL-*.ttf; do
             [[ "$font" == *Condensed* ]] && continue
             fontforge -script "$PATCHER" "$font" --complete --careful --outputdir patched-fonts-nl/Normal
+          done
+
+          # ── Patch Sans ──
+          for font in "$DIST_QUASI"/IoskeleySans-SemiCondensed*.ttf; do
+            fontforge -script "$PATCHER" "$font" --complete --careful --outputdir patched-fonts-quasi/SemiCondensed
+          done
+          for font in "$DIST_QUASI"/IoskeleySans-Condensed*.ttf; do
+            [[ "$font" == *SemiCondensed* ]] && continue
+            fontforge -script "$PATCHER" "$font" --complete --careful --outputdir patched-fonts-quasi/Condensed
+          done
+          for font in "$DIST_QUASI"/IoskeleySans-*.ttf; do
+            [[ "$font" == *Condensed* ]] && continue
+            fontforge -script "$PATCHER" "$font" --complete --careful --outputdir patched-fonts-quasi/Normal
+          done
+
+          # ── Patch Sans NL ──
+          for font in "$DIST_QUASI_NL"/IoskeleySansNL-SemiCondensed*.ttf; do
+            fontforge -script "$PATCHER" "$font" --complete --careful --outputdir patched-fonts-quasi-nl/SemiCondensed
+          done
+          for font in "$DIST_QUASI_NL"/IoskeleySansNL-Condensed*.ttf; do
+            [[ "$font" == *SemiCondensed* ]] && continue
+            fontforge -script "$PATCHER" "$font" --complete --careful --outputdir patched-fonts-quasi-nl/Condensed
+          done
+          for font in "$DIST_QUASI_NL"/IoskeleySansNL-*.ttf; do
+            [[ "$font" == *Condensed* ]] && continue
+            fontforge -script "$PATCHER" "$font" --complete --careful --outputdir patched-fonts-quasi-nl/Normal
           done
 
       - name: Package release archives
         run: |
           DIST="iosevka-src/dist/IoskeleyMono"
           DIST_TERM="iosevka-src/dist/IoskeleyMonoTerm"
+          DIST_NL="iosevka-src/dist/IoskeleyMonoNL"
+          DIST_QUASI="iosevka-src/dist/IoskeleySans"
+          DIST_QUASI_NL="iosevka-src/dist/IoskeleySansNL"
 
           # ── IoskeleyMono.zip — all widths, TTF hinted + unhinted ──────────
           mkdir -p pkg/Normal/Hinted      pkg/Normal/Unhinted
@@ -168,7 +207,6 @@ jobs:
           cd pkg-term && zip -r ../IoskeleyMono-Term.zip . && cd ..
 
           # ── IoskeleyMono-NL.zip — all widths, no ligatures ────────────────
-          DIST_NL="iosevka-src/dist/IoskeleyMonoNL"
           mkdir -p pkg-nl/Normal/Hinted      pkg-nl/Normal/Unhinted
           mkdir -p pkg-nl/SemiCondensed/Hinted pkg-nl/SemiCondensed/Unhinted
           mkdir -p pkg-nl/Condensed/Hinted   pkg-nl/Condensed/Unhinted
@@ -197,10 +235,54 @@ jobs:
           cp patched-fonts-nl/Condensed/*.ttf      pkg-nl-nf/Condensed/
           cd pkg-nl-nf && zip -r ../IoskeleyMono-NL-NerdFont.zip . && cd ..
 
-      - name: Package Web archive
+          # ── IoskeleySans.zip — all widths, TTF hinted + unhinted ──────────
+          mkdir -p pkg-quasi/Normal/Hinted      pkg-quasi/Normal/Unhinted
+          mkdir -p pkg-quasi/SemiCondensed/Hinted pkg-quasi/SemiCondensed/Unhinted
+          mkdir -p pkg-quasi/Condensed/Hinted   pkg-quasi/Condensed/Unhinted
+
+          cp "$DIST_QUASI"/TTF/IoskeleySans-SemiCondensed*.ttf          pkg-quasi/SemiCondensed/Hinted/
+          cp "$DIST_QUASI"/TTF-Unhinted/IoskeleySans-SemiCondensed*.ttf pkg-quasi/SemiCondensed/Unhinted/
+
+          for f in "$DIST_QUASI"/TTF/IoskeleySans-Condensed*.ttf;          do [[ "$f" == *SemiCondensed* ]] && continue; cp "$f" pkg-quasi/Condensed/Hinted/;    done
+          for f in "$DIST_QUASI"/TTF-Unhinted/IoskeleySans-Condensed*.ttf; do [[ "$f" == *SemiCondensed* ]] && continue; cp "$f" pkg-quasi/Condensed/Unhinted/;  done
+          for f in "$DIST_QUASI"/TTF/IoskeleySans-*.ttf;                   do [[ "$f" == *Condensed* ]]     && continue; cp "$f" pkg-quasi/Normal/Hinted/;        done
+          for f in "$DIST_QUASI"/TTF-Unhinted/IoskeleySans-*.ttf;          do [[ "$f" == *Condensed* ]]     && continue; cp "$f" pkg-quasi/Normal/Unhinted/;      done
+
+          cd pkg-quasi && zip -r ../IoskeleySans.zip . && cd ..
+
+          # ── IoskeleySans-NerdFont.zip — all widths, Nerd Font patched ────
+          mkdir -p pkg-quasi-nf/Normal pkg-quasi-nf/SemiCondensed pkg-quasi-nf/Condensed
+          cp patched-fonts-quasi/Normal/*.ttf         pkg-quasi-nf/Normal/
+          cp patched-fonts-quasi/SemiCondensed/*.ttf  pkg-quasi-nf/SemiCondensed/
+          cp patched-fonts-quasi/Condensed/*.ttf      pkg-quasi-nf/Condensed/
+          cd pkg-quasi-nf && zip -r ../IoskeleySans-NerdFont.zip . && cd ..
+
+          # ── IoskeleySans-NL.zip — all widths, no ligatures ───────────────
+          mkdir -p pkg-quasi-nl/Normal/Hinted      pkg-quasi-nl/Normal/Unhinted
+          mkdir -p pkg-quasi-nl/SemiCondensed/Hinted pkg-quasi-nl/SemiCondensed/Unhinted
+          mkdir -p pkg-quasi-nl/Condensed/Hinted   pkg-quasi-nl/Condensed/Unhinted
+
+          cp "$DIST_QUASI_NL"/TTF/IoskeleySansNL-SemiCondensed*.ttf          pkg-quasi-nl/SemiCondensed/Hinted/
+          cp "$DIST_QUASI_NL"/TTF-Unhinted/IoskeleySansNL-SemiCondensed*.ttf pkg-quasi-nl/SemiCondensed/Unhinted/
+
+          for f in "$DIST_QUASI_NL"/TTF/IoskeleySansNL-Condensed*.ttf;          do [[ "$f" == *SemiCondensed* ]] && continue; cp "$f" pkg-quasi-nl/Condensed/Hinted/;   done
+          for f in "$DIST_QUASI_NL"/TTF-Unhinted/IoskeleySansNL-Condensed*.ttf; do [[ "$f" == *SemiCondensed* ]] && continue; cp "$f" pkg-quasi-nl/Condensed/Unhinted/; done
+          for f in "$DIST_QUASI_NL"/TTF/IoskeleySansNL-*.ttf;                   do [[ "$f" == *Condensed* ]]     && continue; cp "$f" pkg-quasi-nl/Normal/Hinted/;       done
+          for f in "$DIST_QUASI_NL"/TTF-Unhinted/IoskeleySansNL-*.ttf;          do [[ "$f" == *Condensed* ]]     && continue; cp "$f" pkg-quasi-nl/Normal/Unhinted/;     done
+
+          cd pkg-quasi-nl && zip -r ../IoskeleySans-NL.zip . && cd ..
+
+          # ── IoskeleySans-NL-NerdFont.zip — no ligatures + Nerd Font ──────
+          mkdir -p pkg-quasi-nl-nf/Normal pkg-quasi-nl-nf/SemiCondensed pkg-quasi-nl-nf/Condensed
+          cp patched-fonts-quasi-nl/Normal/*.ttf         pkg-quasi-nl-nf/Normal/
+          cp patched-fonts-quasi-nl/SemiCondensed/*.ttf  pkg-quasi-nl-nf/SemiCondensed/
+          cp patched-fonts-quasi-nl/Condensed/*.ttf      pkg-quasi-nl-nf/Condensed/
+          cd pkg-quasi-nl-nf && zip -r ../IoskeleySans-NL-NerdFont.zip . && cd ..
+
+      - name: Package Web archives
         run: |
-          cd iosevka-src/dist/IoskeleyMono
-          zip -r ../../../IoskeleyMono-Web.zip WOFF2 WOFF2-Unhinted
+          (cd iosevka-src/dist/IoskeleyMono && zip -r ../../../IoskeleyMono-Web.zip WOFF2 WOFF2-Unhinted)
+          (cd iosevka-src/dist/IoskeleySans && zip -r ../../../IoskeleySans-Web.zip WOFF2 WOFF2-Unhinted)
 
       - name: Set release version
         id: vars
@@ -228,13 +310,19 @@ jobs:
 
             | Situation | Download |
             |---|---|
-            | Editor / IDE | `IoskeleyMono.zip` |
-            | Terminal with icons | `IoskeleyMono-NerdFont.zip` |
-            | Terminal rendering issues | `IoskeleyMono-Term.zip` |
-            | Terminal icons + rendering issues | `IoskeleyMono-Term-NerdFont.zip` |
-            | App that can't disable ligatures | `IoskeleyMono-NL.zip` |
-            | Same + Nerd Font icons | `IoskeleyMono-NL-NerdFont.zip` |
-            | Web | `IoskeleyMono-Web.zip` |
+            | **Editor / IDE (Monospace)** | `IoskeleyMono.zip` |
+            | **Terminal with icons (Monospace)** | `IoskeleyMono-NerdFont.zip` |
+            | **Terminal rendering issues** | `IoskeleyMono-Term.zip` |
+            | **Terminal icons + rendering issues** | `IoskeleyMono-Term-NerdFont.zip` |
+            | **App that can't disable ligatures** | `IoskeleyMono-NL.zip` |
+            | **Same + Nerd Font icons** | `IoskeleyMono-NL-NerdFont.zip` |
+            | **Web (Monospace)** | `IoskeleyMono-Web.zip` |
+            | | |
+            | **Proportional Writing (Sans)** | `IoskeleySans.zip` |
+            | **Proportional + Nerd Font icons** | `IoskeleySans-NerdFont.zip` |
+            | **Sans (No Ligatures)** | `IoskeleySans-NL.zip` |
+            | **Same + Nerd Font icons** | `IoskeleySans-NL-NerdFont.zip` |
+            | **Web (Sans Proportional)** | `IoskeleySans-Web.zip` |
 
             Not sure which to pick? [See the README](https://github.com/ahatem/IoskeleyMono#which-file-do-i-need).
           files: |
@@ -245,5 +333,10 @@ jobs:
             IoskeleyMono-NL.zip
             IoskeleyMono-NL-NerdFont.zip
             IoskeleyMono-Web.zip
+            IoskeleySans.zip
+            IoskeleySans-NerdFont.zip
+            IoskeleySans-NL.zip
+            IoskeleySans-NL-NerdFont.zip
+            IoskeleySans-Web.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ A free, open-source alternative to [Berkeley Mono](https://berkeleygraphics.com/
 
 The name is a mashup: **Iosevka** + **Berkeley** = **Ioskeley**.
 
+> **Bonus Variant:** This repository also includes **Ioskeley Sans**, a quasi-proportional reading font built with the exact same aesthetic design choices.
+
 ---
 
 ## Live Preview
@@ -36,6 +38,8 @@ Download the latest release from the [Releases page](https://github.com/ahatem/I
 
 ### Which file do I need?
 
+#### Standard Monospace Variants (Coding & Terminals)
+
 | Situation | Download |
 |---|---|
 | Editor or IDE (VS Code, JetBrains, Zed…) | `IoskeleyMono.zip` |
@@ -45,6 +49,16 @@ Download the latest release from the [Releases page](https://github.com/ahatem/I
 | App that can't disable ligatures (Xcode…) | `IoskeleyMono-NL.zip` |
 | Same, but also need Nerd Font icons | `IoskeleyMono-NL-NerdFont.zip` |
 | Web / CSS (`@font-face`) | `IoskeleyMono-Web.zip` |
+
+#### Quasi-Proportional Variants (Notes, Prose & UI)
+
+| Situation | Download |
+|---|---|
+| Prose, note-taking, or writing (Obsidian, Typora…) | `IoskeleySans.zip` |
+| Proportional writing with icons | `IoskeleySans-NerdFont.zip` |
+| Proportional app that can't disable ligatures | `IoskeleySans-NL.zip` |
+| Same, but also need Nerd Font icons | `IoskeleySans-NL-NerdFont.zip` |
+| Web / CSS (`@font-face`) | `IoskeleySans-Web.zip` |
 
 > **Not sure?** Start with `IoskeleyMono.zip`.
 
@@ -81,7 +95,16 @@ Install all fonts in your chosen folder — your OS will expose the full weight 
 
 ### About the NL variant
 
-`Ioskeley Mono NL` has all ligature substitutions disabled. Use it in apps that can't toggle ligatures off themselves (e.g. Xcode). Everything else — weights, widths, glyph shapes, metrics — is identical to the standard variant.
+`Ioskeley Mono NL` (and `Ioskeley Sans NL`) has all ligature substitutions disabled. Use it in apps that can't toggle ligatures off themselves (e.g. Xcode). Everything else — weights, widths, glyph shapes, metrics — is identical to the standard variant.
+
+### About the Sans variant
+
+`Ioskeley Sans` uses `spacing = "quasi-proportional"`. Unlike standard monospace fonts where every letter occupies the exact same width, a quasi-proportional font adjusts character widths dynamically to optimize reading layout:
+* Narrow letters like `i`, `l`, and `1` are slimmed down.
+* Wide letters like `m` and `w` are allowed to expand.
+* Dynamic kerning is applied to create a smoother, more natural reading flow.
+
+This maintains the geometric, technical look of the Ioskeley Mono aesthetics, but optimizes the layout for prose. It is incredible for markdown note-taking (in apps like Obsidian), reading documentation, and even coding in environments that support proportional layouts (such as GNU Emacs).
 
 ---
 
@@ -129,10 +152,10 @@ git clone --depth 1 https://github.com/be5invis/Iosevka.git
 cp IoskeleyMono/private-build-plans.toml Iosevka/
 cd Iosevka
 npm install
-npm run build -- contents::IoskeleyMono contents::IoskeleyMonoTerm
+npm run build -- contents::IoskeleyMono contents::IoskeleyMonoTerm contents::IoskeleyMonoNL contents::IoskeleySans contents::IoskeleySansNL
 ```
 
-Output will be in `Iosevka/dist/IoskeleyMono/` and `Iosevka/dist/IoskeleyMonoTerm/`.
+Output will be in the respective folders under `Iosevka/dist/`.
 
 ---
 

--- a/private-build-plans.toml
+++ b/private-build-plans.toml
@@ -311,3 +311,30 @@ essRatioLower = 1.03
 essRatioQuestion = 1.03
 archDepth = 152
 smallArchDepth = 157
+
+[buildPlans.IoskeleySans]
+family = "Ioskeley Sans"
+spacing = "quasi-proportional"
+serifs = "sans"
+noCvSs = true
+exportGlyphNames = false
+
+variants.inherits       = "buildPlans.IoskeleyMono"
+weights.inherits        = "buildPlans.IoskeleyMono"
+widths.inherits         = "buildPlans.IoskeleyMono"
+slopes.inherits         = "buildPlans.IoskeleyMono"
+metricOverride.inherits = "buildPlans.IoskeleyMono"
+
+[buildPlans.IoskeleySansNL]
+family = "Ioskeley Sans NL"
+spacing = "quasi-proportional"
+serifs = "sans"
+noCvSs = true
+noLigation = true
+exportGlyphNames = false
+
+variants.inherits       = "buildPlans.IoskeleySans"
+weights.inherits        = "buildPlans.IoskeleySans"
+widths.inherits         = "buildPlans.IoskeleySans"
+slopes.inherits         = "buildPlans.IoskeleySans"
+metricOverride.inherits = "buildPlans.IoskeleySans"

--- a/site/index.html
+++ b/site/index.html
@@ -41,7 +41,7 @@
     <p class="tagline">
       A free, open-source monospace font crafted to match Berkeley Mono's aesthetic.
       Built by configuring <a href="https://github.com/be5invis/Iosevka" target="_blank" rel="noopener">Iosevka</a>.
-      Three widths, ten weights, italic variants, and Nerd Font support.
+      Three widths, ten weights, italic variants, Nerd Font support, and a quasi-proportional reading variant.
       <strong>Iosevka + Berkeley = Ioskeley</strong>.
     </p>
 
@@ -130,7 +130,9 @@
 
   <!-- Download -->
   <h2 id="download">Download</h2>
-  <p>Not sure which file? Start with <strong>IoskeleyMono.zip</strong>.</p>
+  <p>Not sure which file? Start with <strong>IoskeleyMono.zip</strong> for coding, or <strong>IoskeleySans.zip</strong> for note-taking.</p>
+  
+  <h3 style="margin-top: 1.5rem; margin-bottom: 0.5rem;">1. Monospace Variants (Coding &amp; Terminals)</h3>
   <table class="dl-table">
     <thead>
       <tr><th>File</th><th>Best for</th><th style="text-align:center">Downloads</th><th></th></tr>
@@ -177,6 +179,45 @@
         <td>Web / CSS — WOFF2 for <kbd>@font-face</kbd></td>
         <td class="dl-cell" data-zip="IoskeleyMono-Web.zip"><span class="dl-num">—</span><span class="dl-fill"></span></td>
         <td><a href="https://github.com/ahatem/IoskeleyMono/releases/download/v2.0.0/IoskeleyMono-Web.zip" target="_blank" rel="noopener">Download →</a></td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h3 style="margin-top: 2rem; margin-bottom: 0.5rem;">2. Quasi-Proportional Variants (Notes, Prose &amp; UI)</h3>
+  <table class="dl-table">
+    <thead>
+      <tr><th>File</th><th>Best for</th><th style="text-align:center">Downloads</th><th></th></tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>IoskeleySans.zip</td>
+        <td>Prose, note-taking, or writing — Obsidian, Typora, Notion</td>
+        <td class="dl-cell" data-zip="IoskeleySans.zip"><span class="dl-num">—</span><span class="dl-fill"></span></td>
+        <td><a href="https://github.com/ahatem/IoskeleyMono/releases/download/v2.0.0/IoskeleySans.zip" target="_blank" rel="noopener">Download →</a></td>
+      </tr>
+      <tr>
+        <td>IoskeleySans-NerdFont.zip</td>
+        <td>Proportional writing with Nerd Font icons</td>
+        <td class="dl-cell" data-zip="IoskeleySans-NerdFont.zip"><span class="dl-num">—</span><span class="dl-fill"></span></td>
+        <td><a href="https://github.com/ahatem/IoskeleyMono/releases/download/v2.0.0/IoskeleySans-NerdFont.zip" target="_blank" rel="noopener">Download →</a></td>
+      </tr>
+      <tr>
+        <td>IoskeleySans-NL.zip</td>
+        <td>Proportional apps that can't disable ligatures</td>
+        <td class="dl-cell" data-zip="IoskeleySans-NL.zip"><span class="dl-num">—</span><span class="dl-fill"></span></td>
+        <td><a href="https://github.com/ahatem/IoskeleyMono/releases/download/v2.0.0/IoskeleySans-NL.zip" target="_blank" rel="noopener">Download →</a></td>
+      </tr>
+      <tr>
+        <td>IoskeleySans-NL-NerdFont.zip</td>
+        <td>Same, with Nerd Font icons</td>
+        <td class="dl-cell" data-zip="IoskeleySans-NL-NerdFont.zip"><span class="dl-num">—</span><span class="dl-fill"></span></td>
+        <td><a href="https://github.com/ahatem/IoskeleyMono/releases/download/v2.0.0/IoskeleySans-NL-NerdFont.zip" target="_blank" rel="noopener">Download →</a></td>
+      </tr>
+      <tr>
+        <td>IoskeleySans-Web.zip</td>
+        <td>Web / CSS — WOFF2 for proportional layout</td>
+        <td class="dl-cell" data-zip="IoskeleySans-Web.zip"><span class="dl-num">—</span><span class="dl-fill"></span></td>
+        <td><a href="https://github.com/ahatem/IoskeleyMono/releases/download/v2.0.0/IoskeleySans-Web.zip" target="_blank" rel="noopener">Download →</a></td>
       </tr>
     </tbody>
   </table>
@@ -347,6 +388,18 @@ How vexingly quick daft zebras jump!
       </div>
     </details>
     <details>
+      <summary>What is the Sans variant?</summary>
+      <div class="rel-notes">
+        <p><code>Ioskeley Sans</code> uses <code>spacing = "quasi-proportional"</code>. Unlike standard monospace fonts where every letter occupies the exact same width, a quasi-proportional font adjusts character widths dynamically to optimize reading layout:</p>
+        <ul style="margin: 0.5rem 0 0.5rem 1.25rem; padding: 0; list-style-type: disc;">
+          <li>Narrow letters like <code>i</code>, <code>l</code>, and <code>1</code> are slimmed down.</li>
+          <li>Wide letters like <code>m</code> and <code>w</code> are allowed to expand.</li>
+          <li>Dynamic kerning is applied to create a smoother, more natural reading flow.</li>
+        </ul>
+        <p style="margin-top:0.5rem;">This maintains the geometric, technical aesthetic of Ioskeley Mono, but optimizes the layout for reading prose. It is incredible for markdown note-taking (in apps like Obsidian), reading documentation, and even coding in environments that support proportional layouts (such as GNU Emacs).</p>
+      </div>
+    </details>
+    <details>
       <summary>What's inside each TTF zip?</summary>
       <div class="rel-notes">
         <div class="preview-box" style="font-family:var(--m);font-size:0.78rem;line-height:1.6;">
@@ -377,9 +430,9 @@ git clone --depth 1 https://github.com/be5invis/Iosevka.git
 cp IoskeleyMono/private-build-plans.toml Iosevka/
 cd Iosevka
 npm install
-npm run build -- contents::IoskeleyMono contents::IoskeleyMonoTerm
+npm run build -- contents::IoskeleyMono contents::IoskeleyMonoTerm contents::IoskeleyMonoNL contents::IoskeleySans contents::IoskeleySansNL
   </div>
-  <p style="margin-top:0.75rem;">Output in <code>Iosevka/dist/IoskeleyMono/</code> and <code>Iosevka/dist/IoskeleyMonoTerm/</code>.</p>
+  <p style="margin-top:0.75rem;">Output in the respective folders under <code>Iosevka/dist/</code>.</p>
 
   <hr>
 


### PR DESCRIPTION
Closes #21

Adds a quasi-proportional version of the font, this is useful to have a variable font in coding environments that support it such as GNU Emacs or markdown note-taking applications such as Obsidian

See the difference here:

<img width="925" height="466" alt="image" src="https://github.com/user-attachments/assets/25149e96-0e96-44ef-b18c-391d868c3852" />
