### PR TITLE
Add IoskeleyMonoTermNL variant: term spacing + no ligatures + Nerd Font

### DIFF
--- a/.github/workflows/build-font.yml
+++ b/.github/workflows/build-font.yml
@@ -52,7 +52,7 @@ jobs:
           cp private-build-plans.toml iosevka-src/
           cd iosevka-src
           npm install
-          npm run build -- contents::IoskeleyMono contents::IoskeleyMonoTerm contents::IoskeleyMonoNL contents::IoskeleyMonoWeb
+          npm run build -- contents::IoskeleyMono contents::IoskeleyMonoTerm contents::IoskeleyMonoNL contents::IoskeleyMonoTermNL contents::IoskeleyMonoWeb
 
       - name: Verify build output
         run: |
@@ -66,6 +66,10 @@ jobs:
           fi
           if [ ! -d "iosevka-src/dist/IoskeleyMonoNL/TTF" ]; then
             echo "IoskeleyMonoNL build output not found!"
+            exit 1
+          fi
+          if [ ! -d "iosevka-src/dist/IoskeleyMonoTermNL/TTF" ]; then
+            echo "IoskeleyMonoTermNL build output not found!"
             exit 1
           fi
           if [ ! -d "iosevka-src/dist/IoskeleyMonoWeb/WOFF2" ]; then
@@ -88,9 +92,11 @@ jobs:
           mkdir -p patched-fonts/Normal patched-fonts/SemiCondensed
           mkdir -p patched-fonts-term/Normal patched-fonts-term/SemiCondensed
           mkdir -p patched-fonts-nl/Normal patched-fonts-nl/SemiCondensed
+          mkdir -p patched-fonts-termnl/Normal patched-fonts-termnl/SemiCondensed
           DIST="iosevka-src/dist/IoskeleyMono/TTF"
           DIST_TERM="iosevka-src/dist/IoskeleyMonoTerm/TTF"
           DIST_NL="iosevka-src/dist/IoskeleyMonoNL/TTF"
+          DIST_TERMNL="iosevka-src/dist/IoskeleyMonoTermNL/TTF"
           PATCHER="nerd-fonts-patcher/font-patcher"
 
           for font in "$DIST"/IoskeleyMono-SemiCondensed*.ttf; do
@@ -123,6 +129,16 @@ jobs:
             fontforge -script "$PATCHER" "$font" --complete --careful --mono --outputdir patched-fonts-nl/Normal
           done
 
+          for font in "$DIST_TERMNL"/IoskeleyMonoTermNL-SemiCondensed*.ttf; do
+            fontforge -script "$PATCHER" "$font" --complete --careful --mono --outputdir patched-fonts-termnl/SemiCondensed
+          done
+
+
+          for font in "$DIST_TERMNL"/IoskeleyMonoTermNL-*.ttf; do
+            [[ "$font" == *Condensed* ]] && continue
+            fontforge -script "$PATCHER" "$font" --complete --careful --mono --outputdir patched-fonts-termnl/Normal
+          done
+
       - name: Restore fixed-pitch flag on patched fonts
         run: |
           pip install --quiet fonttools
@@ -131,7 +147,7 @@ jobs:
           from fontTools.ttLib import TTFont
 
           fixed = 0
-          for d in ("patched-fonts", "patched-fonts-term", "patched-fonts-nl"):
+          for d in ("patched-fonts", "patched-fonts-term", "patched-fonts-nl", "patched-fonts-termnl"):
               for f in sorted(Path(d).rglob("*.ttf")):
                   font = TTFont(f)
                   if "post" in font and font["post"].isFixedPitch != 1:
@@ -201,6 +217,12 @@ jobs:
           cp patched-fonts-nl/SemiCondensed/*.ttf  pkg-nl-nf/SemiCondensed/
           cd pkg-nl-nf && zip -r ../IoskeleyMono-NL-NerdFont.zip . && cd ..
 
+          # ── IoskeleyMono-TermNL-NerdFont.zip — term spacing + no ligatures + Nerd Font ─
+          mkdir -p pkg-termnl-nf/Normal pkg-termnl-nf/SemiCondensed
+          cp patched-fonts-termnl/Normal/*.ttf         pkg-termnl-nf/Normal/
+          cp patched-fonts-termnl/SemiCondensed/*.ttf  pkg-termnl-nf/SemiCondensed/
+          cd pkg-termnl-nf && zip -r ../IoskeleyMono-TermNL-NerdFont.zip . && cd ..
+
       - name: Package Web archive
         run: |
           # Built from the subsetted plan. Hinting is ignored by browsers, so
@@ -269,6 +291,7 @@ jobs:
             | A terminal, with Nerd Font icons | `IoskeleyMono-Term-NerdFont.zip` |
             | An app that can't turn ligatures off | `IoskeleyMono-NL.zip` |
             | Same, with Nerd Font icons | `IoskeleyMono-NL-NerdFont.zip` |
+            | A terminal without a ligature toggle (Konsole), with icons | `IoskeleyMono-TermNL-NerdFont.zip` |
             | A website — small subset | `IoskeleyMono-Web.zip` |
             | A website — full coverage | `IoskeleyMono-Web-Full.zip` |
 
@@ -292,6 +315,7 @@ jobs:
             IoskeleyMono-Term-NerdFont.zip
             IoskeleyMono-NL.zip
             IoskeleyMono-NL-NerdFont.zip
+            IoskeleyMono-TermNL-NerdFont.zip
             IoskeleyMono-Web.zip
             IoskeleyMono-Web-Full.zip
         env:

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Grab pre-built packages from the [Releases page](https://github.com/ahatem/Ioske
 | **`IoskeleyMono-Term-NerdFont.zip`** *(terminals + icons)* | Kitty, Ghostty, WezTerm with Neovim, Starship, zsh | ✅ | ✅ |
 | **`IoskeleyMono-NL.zip`** | Environments with forced ligatures (e.g. Xcode) | ❌ | — |
 | **`IoskeleyMono-NL-NerdFont.zip`** | No ligatures + Nerd Font icons | ❌ | ✅ |
+| **`IoskeleyMono-TermNL-NerdFont.zip`** | Terminals with no ligature toggle (e.g. Konsole) + Nerd Font icons | ❌ | ✅ |
 | **`IoskeleyMono-Web.zip`** | Web / CSS `@font-face` — small subset (Latin, punctuation, arrows, box drawing, ≈94 KB/face) | ✅ | — |
 | **`IoskeleyMono-Web-Full.zip`** | Web / CSS `@font-face` — full coverage (Greek, Cyrillic, long arrows, rare math) | ✅ | — |
 
@@ -233,7 +234,7 @@ cp IoskeleyMono/private-build-plans.toml Iosevka/
 # 3. Install dependencies and compile
 cd Iosevka
 npm install
-npm run build -- contents::IoskeleyMono contents::IoskeleyMonoTerm contents::IoskeleyMonoNL contents::IoskeleyMonoWeb
+npm run build -- contents::IoskeleyMono contents::IoskeleyMonoTerm contents::IoskeleyMonoNL contents::IoskeleyMonoTermNL contents::IoskeleyMonoWeb
 ```
 Compiled binaries land in `Iosevka/dist/<PlanName>/`. The workflow pins Iosevka to a known-good tag; check [`build-font.yml`](.github/workflows/build-font.yml) for the current one.
 

--- a/private-build-plans.toml
+++ b/private-build-plans.toml
@@ -309,6 +309,53 @@ essRatioLower = 1.03
 essRatioQuestion = 1.03
 archDepth = 152
 smallArchDepth = 157
+
+# ============================================================
+# TERM + NL VARIANT
+# Combines the Term and NL variants: term spacing (for terminal
+# grid alignment) plus disabled ligature substitutions — for
+# terminals that have no way to toggle ligatures themselves
+# (e.g. Konsole).
+# ============================================================
+
+[buildPlans.IoskeleyMonoTermNL]
+family = "Ioskeley Mono Term NL"
+spacing = "term"
+serifs = "sans"
+noCvSs = true
+noLigation = true
+exportGlyphNames = true
+
+weights.inherits = "buildPlans.IoskeleyMono"
+widths.inherits  = "buildPlans.IoskeleyMono"
+slopes.inherits  = "buildPlans.IoskeleyMono"
+
+[buildPlans.IoskeleyMonoTermNL.variants]
+inherits = "buildPlans.IoskeleyMono"
+
+[buildPlans.IoskeleyMonoTermNL.metricOverride]
+xHeight = 520
+cap = 690
+ascender = 740
+sb = 85
+
+accentWidth = 182
+accentClearance = 76
+accentHeight = 162
+accentStackOffset = 208
+
+leading = 1250
+parenSize = 860
+dotSize = 'blend(weight, [100, 110], [400, 125], [900, 150])'
+periodSize = 140
+
+essRatio = 1.03
+essRatioUpper = 1.03
+essRatioLower = 1.03
+essRatioQuestion = 1.03
+archDepth = 152
+smallArchDepth = 157
+
 # ============================================================
 # WEB VARIANT
 # Same design, trimmed character set. The full build carries


### PR DESCRIPTION
## Summary

Adds a new `IoskeleyMonoTermNL` build plan that combines two existing variants:

- `spacing = "term"` (from the `Term` variant) — fixes arrow/box-drawing rendering inside the terminal cell
- `noLigation = true` (from the `NL` variant) — disables `calt` ligature substitutions at the font level

This covers terminals that have no way to toggle ligatures themselves, such as **Konsole** (unlike Kitty's `disable_ligatures`, VS Code's `editor.fontLigatures`, or WezTerm's `harfbuzz_features`).

Wired into `build-font.yml` the same way as the other variants:
- Built via `contents::IoskeleyMonoTermNL`
- Patched with the Nerd Font patcher into `patched-fonts-termnl/`
- Packaged as `IoskeleyMono-TermNL-NerdFont.zip` (Normal + SemiCondensed, matching the other `*-NerdFont.zip` packages)
- Added to the release asset list, release notes table, and README variant table

I built and tested this variant locally (Iosevka v34.4.0, same pipeline as CI) before opening this — confirmed as monospace by fontconfig, ligature-free, and Nerd Font glyphs render correctly.

## Test plan

- [ ] CI builds `IoskeleyMonoTermNL` successfully (`Verify build output` step passes)
- [ ] Nerd Font patching step produces `patched-fonts-termnl/Normal` and `patched-fonts-termnl/SemiCondensed`
- [ ] `IoskeleyMono-TermNL-NerdFont.zip` is attached to the release
- [ ] Installed font resolves as `IoskeleyMonoTermNL Nerd Font Mono`, detected as monospace (`fc-match` / Font Book), ligatures do not render, Nerd Font icons render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)